### PR TITLE
chore: normalize MIT copyright attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Anand Pant
+Copyright (c) 2026 SHPIT LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Why
Align MIT license attribution to a consistent legal owner format across SHPIT repositories.

## What Changed
- Updated `LICENSE` copyright line to `Copyright (c) 2026 SHPIT LLC`