### PR TITLE
chore: sync blacksmith runners and copyright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   verify:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -50,7 +50,7 @@ jobs:
           path: out/enricher_linux_amd64
 
   gemini-e2e:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: verify
     steps:
       - name: Check Gemini secrets
@@ -98,7 +98,7 @@ jobs:
           if-no-files-found: warn
 
   docker-compose-e2e:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: verify
     steps:
       - name: Check Gemini secrets

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -23,7 +23,7 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&
       !contains(github.event.workflow_run.head_commit.message, '[skip ci]')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Anand Pant
+Copyright (c) 2026 SHPIT LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update LICENSE copyright to SHPIT LLC.
- Move non-docker GitHub Actions jobs to blacksmith-2vcpu-ubuntu-2404.
- Keep docker/publish jobs on blacksmith-4vcpu-ubuntu-2404.
- Switch docker build jobs to use Blacksmith builder/actions.

## Validation
- ./dev verify
- go test ./...