### PR TITLE
Remove obsolete Foundry compatibility paths

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -47,7 +47,7 @@ Foundry pipeline-mode containers are provided file paths via environment variabl
 Service discovery:
 
 - `FOUNDRY_SERVICE_DISCOVERY_V2`: file path containing Foundry service base URLs. The code reads `api_gateway` for dataset APIs and `stream_proxy` for stream APIs.
-- `FOUNDRY_URL`: optional local/back-compat fallback when service discovery is not available.
+- `FOUNDRY_URL`: optional local-dev shorthand when service discovery is not available.
 
 Additional configuration this module expects:
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -155,10 +155,6 @@ It supports:
   - `POST /api/v2/datasets/{rid}/files/{filePath...}/upload?transactionRid={txn}` (upload file into txn)
   - `POST /api/v2/datasets/{rid}/transactions/{txn}/commit` (commit txn)
 
-- Dataset API (v1, minimal/back-compat)
-  - `GET /api/v1/datasets/{rid}/readTable`
-  - `PUT /api/v1/datasets/{rid}/transactions/{txn}/files/{path...}`
-
 - Stream-proxy API (optional; only for stream RIDs registered via `MOCK_FOUNDRY_STREAM_RIDS`)
   - `GET  /stream-proxy/api/streams/{rid}/branches/{branch}/records`
   - `POST /stream-proxy/api/streams/{rid}/branches/{branch}/jsonRecord`

--- a/docs/FOUNDRY_PARITY.md
+++ b/docs/FOUNDRY_PARITY.md
@@ -164,11 +164,11 @@ This repo’s runtime contract is:
 
 - `api_gateway` resolves dataset/general Foundry API calls
 - `stream_proxy` resolves stream/high-scale calls
-- fallback `FOUNDRY_URL` may be supported locally, but is a convenience path, not the primary platform contract
+- `FOUNDRY_URL` may be supported locally as a development shorthand, but it is not the primary platform contract
 
 ### Cleanup implication
 
-The parity doc and code should make clear that `FOUNDRY_URL` is a back-compat/local convenience, while service discovery is the primary Foundry-native contract.
+The parity doc and code should make clear that service discovery is the primary Foundry-native contract.
 
 ---
 
@@ -330,7 +330,7 @@ The repo relies on `readTable`.
 
 Official SDKs confirm parameters including:
 
-- `branchName` / older `branchId`
+- `branchName`
 - `startTransactionRid`
 - `endTransactionRid`
 - `format`

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,7 +25,7 @@ You must provide (via compute module configuration):
 
 - `GEMINI_MODEL`: Gemini model name (do not hardcode in code; configure per environment)
 
-`FOUNDRY_URL` remains supported as a local/back-compat fallback when service discovery is unavailable.
+`FOUNDRY_URL` remains supported as a local-dev shorthand when service discovery is unavailable.
 
 Gemini API key (recommended: Foundry Sources):
 
@@ -85,7 +85,7 @@ At minimum, expect to allowlist:
 Confirm exact domains from the client library / runtime behavior before locking the policy.
 
 In addition, if your module calls Foundry REST APIs (this repo does), you should plan to allow access to the Foundry service hosts
-resolved by `FOUNDRY_SERVICE_DISCOVERY_V2` (or the `FOUNDRY_URL` fallback in local/back-compat environments). This does not mean
+resolved by `FOUNDRY_SERVICE_DISCOVERY_V2` (or the `FOUNDRY_URL` shorthand in local development). This does not mean
 "leaving Foundry"; it is simply allowing the container to make HTTPS requests to the stack's API gateway and stream-proxy.
 
 Practical pattern:

--- a/pkg/foundry/client.go
+++ b/pkg/foundry/client.go
@@ -29,7 +29,6 @@ type Client struct {
 
 type branchResponse struct {
 	Name           string `json:"name"`
-	BranchID       string `json:"branchId"`
 	TransactionRID string `json:"transactionRid"`
 }
 
@@ -166,7 +165,6 @@ func (c *Client) ReadTableCSV(ctx context.Context, datasetRID, branch string) ([
 	}
 
 	q := url.Values{}
-	// Dataset API v2 uses branchName; branchId is accepted by some older APIs.
 	q.Set("branchName", branch)
 	if strings.TrimSpace(txnRID) != "" {
 		q.Set("startTransactionRid", txnRID)
@@ -412,11 +410,7 @@ type createTxnRequest struct {
 }
 
 type createTxnResponse struct {
-	// Foundry returns a Transaction object with a transaction RID.
 	RID string `json:"rid"`
-
-	// Legacy: some mocks may return transactionId.
-	TransactionID string `json:"transactionId"`
 }
 
 // CreateTransaction creates a dataset transaction and returns the transaction id.
@@ -462,10 +456,7 @@ func (c *Client) CreateTransaction(ctx context.Context, datasetRID, branch strin
 		return "", fmt.Errorf("parse create transaction response: %w", err)
 	}
 
-	txnID := strings.TrimSpace(out.TransactionID)
-	if txnID == "" {
-		txnID = strings.TrimSpace(out.RID)
-	}
+	txnID := strings.TrimSpace(out.RID)
 	if txnID == "" {
 		return "", fmt.Errorf("create transaction response missing rid")
 	}

--- a/pkg/foundry/env.go
+++ b/pkg/foundry/env.go
@@ -59,7 +59,7 @@ func loadServicesFromEnv() (Services, error) {
 		return loadServicesFromDiscoveryFile(p)
 	}
 
-	// Back-compat: allow explicit FOUNDRY_URL when service discovery is not present.
+	// Local dev shorthand: allow explicit FOUNDRY_URL when service discovery is not present.
 	foundryURL := strings.TrimSpace(os.Getenv("FOUNDRY_URL"))
 	if foundryURL == "" {
 		return Services{}, fmt.Errorf("FOUNDRY_SERVICE_DISCOVERY_V2 or FOUNDRY_URL is required")

--- a/pkg/mockfoundry/server.go
+++ b/pkg/mockfoundry/server.go
@@ -160,7 +160,6 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/__debug/calls", s.handleDebugCalls)
 	mux.HandleFunc("/__debug/uploads", s.handleDebugUploads)
 	mux.HandleFunc("/__debug/streams", s.handleDebugStreams)
-	mux.HandleFunc("/api/v1/datasets/", s.handleV1Datasets)
 	mux.HandleFunc("/api/v2/datasets/", s.handleV2Datasets)
 	mux.HandleFunc("/stream-proxy/api/streams/", s.handleStreamProxy)
 	return mux
@@ -366,63 +365,6 @@ func (s *Server) handleStreamProxy(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) handleV1Datasets(w http.ResponseWriter, r *http.Request) {
-	s.recordCall(r)
-	if !s.authorize(w, r) {
-		return
-	}
-
-	// /api/v1/datasets/{rid}/readTable
-	// /api/v1/datasets/{rid}/transactions/{txn}/files/{path...}
-	rest := strings.TrimPrefix(r.URL.Path, "/api/v1/datasets/")
-	parts := strings.Split(rest, "/")
-	if len(parts) < 2 {
-		http.NotFound(w, r)
-		return
-	}
-	rid := parts[0]
-	if !isSafeToken(rid) {
-		writeAPIError(w, http.StatusBadRequest, "Conjure:InvalidArgument", "INVALID_ARGUMENT", map[string]any{
-			"datasetRid": rid,
-		})
-		return
-	}
-
-	if len(parts) == 2 && parts[1] == "readTable" {
-		if r.Method != http.MethodGet {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-		s.serveReadTableCSV(w, r, rid)
-		return
-	}
-
-	if len(parts) >= 5 && parts[1] == "transactions" && parts[3] == "files" {
-		if r.Method != http.MethodPut {
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			return
-		}
-		txnID := parts[2]
-		if !isSafeToken(txnID) {
-			writeAPIError(w, http.StatusBadRequest, "Conjure:InvalidArgument", "INVALID_ARGUMENT", map[string]any{
-				"transactionRid": txnID,
-			})
-			return
-		}
-		filePath := strings.Join(parts[4:], "/")
-		if !isSafeFilePath(filePath) {
-			writeAPIError(w, http.StatusBadRequest, "InvalidFilePath", "INVALID_ARGUMENT", map[string]any{
-				"filePath": filePath,
-			})
-			return
-		}
-		s.handleUpload(w, r, rid, txnID, filePath)
-		return
-	}
-
-	http.NotFound(w, r)
-}
-
 func (s *Server) handleV2Datasets(w http.ResponseWriter, r *http.Request) {
 	s.recordCall(r)
 	if !s.authorize(w, r) {
@@ -465,6 +407,9 @@ func (s *Server) handleV2Datasets(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
+		if rejectUnsupportedQueryParam(w, r, "branchId") {
+			return
+		}
 		s.serveReadTableCSV(w, r, rid)
 		return
 	}
@@ -504,8 +449,8 @@ func (s *Server) handleV2Datasets(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		txnID := strings.TrimSpace(r.URL.Query().Get("transactionRid"))
-		if txnID == "" {
-			txnID = strings.TrimSpace(r.URL.Query().Get("transactionId"))
+		if rejectUnsupportedQueryParam(w, r, "transactionId") {
+			return
 		}
 		if txnID == "" || !isSafeToken(txnID) {
 			writeAPIError(w, http.StatusBadRequest, "Conjure:InvalidArgument", "INVALID_ARGUMENT", map[string]any{
@@ -796,6 +741,10 @@ func (s *Server) handleListTransactions(w http.ResponseWriter, r *http.Request, 
 }
 
 func (s *Server) handleCreateTransaction(w http.ResponseWriter, r *http.Request, datasetRID string) {
+	if rejectUnsupportedQueryParam(w, r, "branchId") {
+		return
+	}
+
 	var req createTxnReq
 	if r.Body != nil {
 		b, _ := io.ReadAll(r.Body)
@@ -818,9 +767,6 @@ func (s *Server) handleCreateTransaction(w http.ResponseWriter, r *http.Request,
 	s.mu.Lock()
 	branch := normalizeBranch(r.URL.Query().Get("branchName"))
 	if strings.TrimSpace(r.URL.Query().Get("branchName")) == "" {
-		branch = normalizeBranch(r.URL.Query().Get("branchId"))
-	}
-	if strings.TrimSpace(r.URL.Query().Get("branchName")) == "" && strings.TrimSpace(r.URL.Query().Get("branchId")) == "" {
 		branch = normalizeBranch(req.Branch)
 	}
 
@@ -1124,11 +1070,17 @@ func copyNonEmptyStrings(vals []string) []string {
 }
 
 func branchFromReadTableQuery(r *http.Request) string {
-	branch := strings.TrimSpace(r.URL.Query().Get("branchName"))
-	if branch == "" {
-		branch = strings.TrimSpace(r.URL.Query().Get("branchId"))
+	return normalizeBranch(r.URL.Query().Get("branchName"))
+}
+
+func rejectUnsupportedQueryParam(w http.ResponseWriter, r *http.Request, name string) bool {
+	if !r.URL.Query().Has(name) {
+		return false
 	}
-	return normalizeBranch(branch)
+	writeAPIError(w, http.StatusBadRequest, "UnsupportedQueryParameter", "INVALID_ARGUMENT", map[string]any{
+		"parameter": name,
+	})
+	return true
 }
 
 func normalizeBranch(branch string) string {

--- a/pkg/mockfoundry/server_test.go
+++ b/pkg/mockfoundry/server_test.go
@@ -280,6 +280,56 @@ func TestMockFoundry_MissingDatasetViewIsDistinctFromAuthFailure(t *testing.T) {
 	}
 }
 
+func TestMockFoundry_RejectsRemovedCompatibilitySurfaces(t *testing.T) {
+	t.Parallel()
+
+	inputDir := t.TempDir()
+	uploadDir := t.TempDir()
+
+	srv := mockfoundry.New(inputDir, uploadDir)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := foundry.NewClient(ts.URL+"/api", ts.URL+"/stream-proxy/api", "dummy-token", "")
+	if err != nil {
+		t.Fatalf("new foundry client: %v", err)
+	}
+	datasetRID := "ri.foundry.main.dataset.91919191-9191-9191-9191-919191919191"
+
+	resp, err := http.Get(ts.URL + "/api/v1/datasets/" + datasetRID + "/readTable")
+	if err != nil {
+		t.Fatalf("read v1 endpoint: %v", err)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("v1 readTable status=%d want 404", resp.StatusCode)
+	}
+	_ = resp.Body.Close()
+
+	txnID, err := client.CreateTransaction(ctx, datasetRID, "master")
+	if err != nil {
+		t.Fatalf("create transaction: %v", err)
+	}
+
+	resp, err = http.Post(ts.URL+"/api/v2/datasets/"+datasetRID+"/files/enriched.csv/upload?transactionId="+txnID, "text/csv", strings.NewReader("email\nalice@example.com\n"))
+	if err != nil {
+		t.Fatalf("upload using transactionId: %v", err)
+	}
+	assertAPIError(t, resp, http.StatusBadRequest, "UnsupportedQueryParameter")
+
+	resp, err = http.Post(ts.URL+"/api/v2/datasets/"+datasetRID+"/transactions?branchId=feature", "application/json", strings.NewReader(`{"transactionType":"SNAPSHOT"}`))
+	if err != nil {
+		t.Fatalf("create transaction using branchId: %v", err)
+	}
+	assertAPIError(t, resp, http.StatusBadRequest, "UnsupportedQueryParameter")
+
+	resp, err = http.Get(ts.URL + "/api/v2/datasets/" + datasetRID + "/readTable?branchId=feature")
+	if err != nil {
+		t.Fatalf("readTable using branchId: %v", err)
+	}
+	assertAPIError(t, resp, http.StatusBadRequest, "UnsupportedQueryParameter")
+}
+
 func createUploadCommit(t *testing.T, ctx context.Context, client *foundry.Client, datasetRID, branch, filePath string, csvBytes []byte) string {
 	t.Helper()
 	txnID, err := client.CreateTransaction(ctx, datasetRID, branch)
@@ -293,6 +343,25 @@ func createUploadCommit(t *testing.T, ctx context.Context, client *foundry.Clien
 		t.Fatalf("commit transaction branch=%q txn=%q: %v", branch, txnID, err)
 	}
 	return txnID
+}
+
+func assertAPIError(t *testing.T, resp *http.Response, wantStatus int, wantErrorName string) {
+	t.Helper()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != wantStatus {
+		t.Fatalf("status=%d want %d", resp.StatusCode, wantStatus)
+	}
+	var body struct {
+		ErrorName string `json:"errorName"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body.ErrorName != wantErrorName {
+		t.Fatalf("errorName=%q want %q", body.ErrorName, wantErrorName)
+	}
 }
 
 func TestMockFoundry_StreamReadTableUsesConfiguredHeader(t *testing.T) {


### PR DESCRIPTION
## Summary

Removes legacy compatibility surfaces that are not part of the current template contract before starting the broader DevX/bootstrap work.

## What changed

- Removed the untested mock `/api/v1/datasets/...` surface.
- Removed `transactionId` response/query fallback handling; the supported field/parameter is `rid` / `transactionRid`.
- Removed `branchId` fallback handling; the supported query parameter is `branchName`.
- Added mock tests that assert removed compatibility surfaces are rejected.
- Reframed `FOUNDRY_URL` docs/comments as a local-dev shorthand, not backward compatibility.

## Verification

- `go test ./pkg/mockfoundry ./pkg/foundry ./internal/app ./pkg/pipeline/io/foundry`
- `./dev verify`
- `./dev test -v`
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o out/enricher_linux_amd64 ./cmd/enricher`

## Notes

`FOUNDRY_URL` remains because it is still actively used by the local compose/dev harness. It is now documented as local-dev shorthand rather than a compatibility guarantee.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shpitdev/palantir-compute-module-pipeline-template/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
