### PR TITLE
Keep dev-scaffolded projects on the local checkout

### DIFF
--- a/dev
+++ b/dev
@@ -456,7 +456,8 @@ main() {
       fi
       ./godelw verify --apply=false "$@"
       ./test/scripts/verify_public_modules.sh
-      exec ./test/scripts/dev_cli_test.sh
+      ./test/scripts/dev_cli_test.sh
+      exec ./test/scripts/foundry_cmgo_dev_shim_test.sh
       ;;
     test)
       shift

--- a/scripts/foundry-cmgo-dev
+++ b/scripts/foundry-cmgo-dev
@@ -29,6 +29,10 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 inject_local_replace_for_new() {
+  if (($# == 0)); then
+    return
+  fi
+
   if [[ "${1:-}" != "new" ]]; then
     printf '%s\0' "$@"
     return

--- a/scripts/foundry-cmgo-dev
+++ b/scripts/foundry-cmgo-dev
@@ -28,5 +28,25 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+inject_local_replace_for_new() {
+  if [[ "${1:-}" != "new" ]]; then
+    printf '%s\0' "$@"
+    return
+  fi
+
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --local-replace|--local-replace=*)
+        printf '%s\0' "$@"
+        return
+        ;;
+    esac
+  done
+
+  printf '%s\0' "$@" --local-replace "$REPO_ROOT"
+}
+
 go -C "$REPO_ROOT" build -trimpath -o "$TMP_BIN" ./cmd/foundry-cmgo
-"$TMP_BIN" "$@"
+mapfile -d '' -t forwarded_args < <(inject_local_replace_for_new "$@")
+"$TMP_BIN" "${forwarded_args[@]}"

--- a/test/scripts/foundry_cmgo_dev_shim_test.sh
+++ b/test/scripts/foundry_cmgo_dev_shim_test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+pass() {
+  echo "ok: $1"
+}
+
+fail() {
+  echo "fail: $1" >&2
+  exit 1
+}
+
+assert_contains_file() {
+  local path="$1"
+  local needle="$2"
+  local message="$3"
+  if ! grep -Fq -- "$needle" "$path"; then
+    echo "--- ${path} ---" >&2
+    cat "$path" >&2
+    fail "$message (missing: ${needle})"
+  fi
+}
+
+"${ROOT_DIR}/scripts/foundry-cmgo-dev" new \
+  --name shim-default \
+  --module example.com/acme/shim-default \
+  --dir "${TMP_DIR}/shim-default" \
+  --example dataset >/tmp/foundry-cmgo-dev-shim-default.out
+assert_contains_file "${TMP_DIR}/shim-default/go.mod" "replace github.com/palantir/palantir-compute-module-pipeline-search => ${ROOT_DIR}" "dev shim should inject local replace for new"
+pass "dev shim injects local replace by default"
+
+"${ROOT_DIR}/scripts/foundry-cmgo-dev" new \
+  --name shim-explicit \
+  --module example.com/acme/shim-explicit \
+  --dir "${TMP_DIR}/shim-explicit" \
+  --example dataset \
+  --local-replace /tmp/explicit-replace >/tmp/foundry-cmgo-dev-shim-explicit.out
+assert_contains_file "${TMP_DIR}/shim-explicit/go.mod" "replace github.com/palantir/palantir-compute-module-pipeline-search => /tmp/explicit-replace" "dev shim should preserve explicit local replace"
+pass "dev shim preserves explicit local replace"

--- a/test/scripts/foundry_cmgo_dev_shim_test.sh
+++ b/test/scripts/foundry_cmgo_dev_shim_test.sh
@@ -25,6 +25,14 @@ assert_contains_file() {
   fi
 }
 
+"${ROOT_DIR}/scripts/foundry-cmgo-dev" >/tmp/foundry-cmgo-dev-shim-noargs.out 2>&1 || true
+assert_contains_file /tmp/foundry-cmgo-dev-shim-noargs.out "Usage:" "dev shim should forward zero args as zero args"
+if grep -Fq "unknown command:" /tmp/foundry-cmgo-dev-shim-noargs.out; then
+  cat /tmp/foundry-cmgo-dev-shim-noargs.out >&2
+  fail "dev shim should not pass a spurious empty argument"
+fi
+pass "dev shim preserves no-args usage"
+
 "${ROOT_DIR}/scripts/foundry-cmgo-dev" new \
   --name shim-default \
   --module example.com/acme/shim-default \


### PR DESCRIPTION
## Summary
- dogfooded `foundry-cmgo-dev new` with Claude/acpx against a real Milwaukee matching use case
- fixed the dev shim so generated local projects automatically get `--local-replace <repo checkout>` for `new`
- added a shim regression test and wired it into `./dev verify`

## Dogfood evidence
First Claude pass got blocked because the generated project tried to fetch `github.com/palantir/palantir-compute-module-pipeline-search v0.0.35` instead of using the local checkout. After the shim fix, a fresh Claude v2 project scaffolded cleanly without manual `replace` edits and completed the full workflow:

- Workspace: `/home/anandpant/Development/palantir/foundry-cmgo-testing/milwaukee-matcher-v2`
- Final review doc: `/home/anandpant/Development/palantir/foundry-cmgo-testing/MILWAUKEE_USE_CASE_REVIEW.md`
- Output: 30,777 retailer rows, 25,733 matched (83.6%), 25,183 exact (81.8%)
- `foundry-cmgo preview`: passed, 30,777 rows
- `foundry-cmgo build`: passed with default Docker container, 30,777 rows
- `foundry-cmgo inspect last/config/outputs`: all passed

## Testing
- `go test ./...`
- `go vet ./...`
- `./dev verify`
- `./test/scripts/foundry_cmgo_dev_shim_test.sh`
- `./test/scripts/verify_foundry_cmgo_generated.sh`
- Milwaukee dogfood project:
  - `go test ./...`
  - `scripts/foundry-cmgo-dev preview --rows 2`
  - `scripts/foundry-cmgo-dev build`
  - `scripts/foundry-cmgo-dev inspect last`
  - `scripts/foundry-cmgo-dev inspect config`
  - `scripts/foundry-cmgo-dev inspect outputs`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/shpitdev/palantir-compute-module-pipeline-template/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
